### PR TITLE
Backstory description edits - mainly spelling and grammar

### DIFF
--- a/1.3/Defs/Backstories/Backstories_Faction_TribunalTemple.xml
+++ b/1.3/Defs/Backstories/Backstories_Faction_TribunalTemple.xml
@@ -5,7 +5,7 @@
 		<defName>ESCP_Dunmer_ArmigerBackstory</defName>
 		<title>buoyant armiger member</title>
 		<titleShort>buoyant armiger member</titleShort>
-		<baseDescription>[PAWN_nameDef] was a member of the Buoyant Armigers, a mercenary faction of sorts working for the Tribunal Temple. After the fall of the Tribunal [PAWN_nameDef] decided that [PAWN_pronoun] wanted to explore foreign lands.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was a member of the Buoyant Armigers, a militant order of the Tribunal Temple. After the fall of the Tribunal [PAWN_nameDef] decided that [PAWN_pronoun] wanted to explore foreign lands.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -78,7 +78,7 @@
 		<defName>ESCP_Dunmer_HandOfTheQueenBackstory</defName>
 		<title>hand of Almalexia</title>
 		<titleShort>hand of Almalexia</titleShort>
-		<baseDescription>[PAWN_nameDef] wasn't just an ordinary ordinator, [PAWN_pronoun] was on the hands of Almalexia. [PAWN_pronoun] served Almalexia with unwavering loyalty, until the very end.\n\nAfter the fall of the tribunal [PAWN_nameDef] decided to start [PAWN_possessive] life anew, and fled Mournhold.</baseDescription>
+		<baseDescription>[PAWN_nameDef] wasn't just an ordinary ordinator, [PAWN_pronoun] was one of the hands of Almalexia. [PAWN_pronoun] served Almalexia with unwavering loyalty, until the very end.\n\nAfter the fall of the tribunal [PAWN_nameDef] decided to start [PAWN_possessive] life anew, and fled Mournhold.</baseDescription>
 		<slot>Adulthood</slot>
 		<bodyTypeMale>Male</bodyTypeMale>
 		<bodyTypeFemale>Female</bodyTypeFemale>

--- a/1.3/Defs/Backstories/Backstories_GenericAdult.xml
+++ b/1.3/Defs/Backstories/Backstories_GenericAdult.xml
@@ -66,7 +66,7 @@
 		<defName>ESCP_Dunmer_KwamaBackstory</defName>
 		<title>kwama egg miner</title>
 		<titleShort>egg miner</titleShort>
-		<baseDescription>[PAWN_nameDef] worked tirelessly in a kwama egg mine for a considerable number of years. In this time [PAWN_pronoun] harvested many kwama eggs, and  may have even kept a few as souvenirs.</baseDescription>
+		<baseDescription>[PAWN_nameDef] worked tirelessly in a kwama egg mine for a considerable number of years. In this time [PAWN_pronoun] harvested many kwama eggs, and may have even kept a few as souvenirs.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -254,7 +254,7 @@
 		<defName>ESCP_Dunmer_SkoomaBackstory</defName>
 		<title>skooma seller</title>
 		<titleShort>entrepreneur</titleShort>
-		<baseDescription>[PAWN_nameDef] had the brilliant idea of starting [PAWN_pronoun] own skooma buisness, a bustling market with profit margins most could only dream of. After a run in with an Ordinator, [PAWN_nameDef] decided to sample [PAWN_possessive] own product, leaving the past few years a blur.</baseDescription>
+		<baseDescription>[PAWN_nameDef] had the brilliant idea of starting [PAWN_possessive] own skooma buisness, a bustling market with profit margins most could only dream of. After a run in with an Ordinator, [PAWN_nameDef] decided to sample [PAWN_possessive] own product, leaving the past few years a blur.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -354,7 +354,7 @@
 		<defName>ESCP_Dunmer_ScuttleBackstory</defName>
 		<title>scuttle cook</title>
 		<titleShort>scuttle cook</titleShort>
-		<baseDescription>[PAWN_nameDef] has always maintained that [PAWN_pronoun] invented scuttle, due to [PAWN_possessive] dislike of insect meat. Everyone around [PAWN_possessive] knew it was a lie, but the scuttle was very tasty, so they feigned belief in [PAWN_nameDef] anyway.</baseDescription>
+		<baseDescription>[PAWN_nameDef] has always maintained that [PAWN_pronoun] invented scuttle, due to [PAWN_possessive] dislike of insect meat. Everyone around [PAWN_objective] knew it was a lie, but the scuttle was very tasty, so they feigned belief in [PAWN_nameDef] anyway.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -419,7 +419,7 @@
 		<defName>ESCP_Dunmer_GhostFenceBackstory</defName>
 		<title>ghost fence maintainer</title>
 		<titleShort>ghost fence</titleShort>
-		<baseDescription>[PAWN_nameDef] spent quite a few years maintaining Ghostfence, a difficult, but highly rewarding job. It was a bittersweet moment when Ghostfence was lowered. While [PAWN_nameDef] knew that the blight was gone, [PAWN_nameDef] also knew [PAWN_pronoun] was about to become unemployed.</baseDescription>
+		<baseDescription>[PAWN_nameDef] spent quite a few years maintaining the Great Ghostfence, a difficult, but highly rewarding job. It was a bittersweet moment when the Ghostfence was lowered. While [PAWN_nameDef] knew that the blight was gone, [PAWN_nameDef] also knew [PAWN_pronoun] was about to become unemployed.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -587,7 +587,7 @@
 		<defName>ESCP_Dunmer_GondolaBackstory</defName>
 		<title>vivec gondolier</title>
 		<titleShort>gondolier</titleShort>
-		<baseDescription>[PAWN_nameDef] was one of the many gondoliers working in the Vivec canals, and spent many days transporting Dunmer, and some N'wah, between the cantons. Whilst [PAWN_nameDef] found the job enjoyable, [PAWN_pronoun] was always annoyed watching all the potential customers simply walk past, and over a bridge to the next canton.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was one of the many gondoliers working in the Vivec canals, and spent many days transporting Dunmer, and some n'wah, between the cantons. Whilst [PAWN_nameDef] found the job enjoyable, [PAWN_pronoun] was always annoyed watching all the potential customers simply walk past, and over a bridge to the next canton.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -618,7 +618,7 @@
 		<defName>ESCP_Dunmer_AshYamBackstory</defName>
 		<title>ash yam farmer</title>
 		<titleShort>ash yam farmer</titleShort>
-		<baseDescription>Back in Vvardenfell [PAWN_nameDef] had a magnificent ash yam farm. The products of [PAWN_possessive] hard labour fed many slaves, up until a wild guar herd decided they were hungry.\n\n[PAWN_nameDef] slew every last guar that was even remotely close to [PAWN_possessive] farm. Of course this simply attracted a flock of cliff racers, and [PAWN_nameDef]'s farm was soon uninhabitable.</baseDescription>
+		<baseDescription>Back in Vvardenfell [PAWN_nameDef] had a magnificent ash yam farm. The products of [PAWN_possessive] hard labour fed many slaves, up until a herd of wild guar decided they were hungry.\n\n[PAWN_nameDef] slew every last guar that was even remotely close to [PAWN_possessive] farm. Of course this simply attracted a flock of cliff racers, and [PAWN_nameDef]'s farm was soon uninhabitable.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -881,7 +881,7 @@
 		<defName>ESCP_Dunmer_VvardvarkBackstory</defName>
 		<title>vvardvark breeder</title>
 		<titleShort>vvardvark breeder</titleShort>
-		<baseDescription>[PAWN_nameDef] once owned a small housepod in Sadrith Mora, where [PAWN_pronoun] bred vvardvarks for the local Telvanni. The sheer amount of filth produced by these tiny creatures swiftly broke [PAWN_possessive], and since then [PAWN_nameDef] refuses to clean even the smallest of messes.</baseDescription>
+		<baseDescription>[PAWN_nameDef] once owned a small housepod in Sadrith Mora, where [PAWN_pronoun] bred vvardvarks for the local Telvanni. The sheer amount of filth produced by these tiny creatures swiftly broke [PAWN_objective], and since then [PAWN_nameDef] refuses to clean even the smallest of messes.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -1016,7 +1016,7 @@
 		<defName>ESCP_Dunmer_PoetBackstory</defName>
 		<title>wandering poet</title>
 		<titleShort>poet</titleShort>
-		<baseDescription>Inspired by the wonderful tales told by Vivec, [PAWN_nameDef] became a wandering poet. [PAWN_nameDef]'s adventures were quite dull and uneventful, though the stories [PAWN_pronoun] told were anything but. Sadly, at the end of the day, [PAWN_possessive] tales were nothing compared to those told b Vivec, and [PAWN_pronoun] often had to cook dinner for [PAWN_possessive]self.</baseDescription>
+		<baseDescription>Inspired by the wonderful tales told by Vivec, [PAWN_nameDef] became a wandering poet. [PAWN_nameDef]'s adventures were quite dull and uneventful, though the stories [PAWN_pronoun] told were anything but. Sadly, at the end of the day, [PAWN_possessive] tales were nothing compared to those told by Vivec, and [PAWN_pronoun] often had to cook dinner for [PAWN_possessive]self.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -1047,7 +1047,7 @@
 		<defName>ESCP_Dunmer_ChairMakerBackstory</defName>
 		<title>chair crafter</title>
 		<titleShort>crafter</titleShort>
-		<baseDescription>[PAWN_nameDef] earned a living making and selling chairs, with the occasional table thrown in too. [PAWN_possessive] work caught even managed to catch the eye of a rather high ranking member of Great House Telvanni. One day [PAWN_nameDef] woke up, ready to fulfil the days orders, only to find every single chair, and table, missing.</baseDescription>
+		<baseDescription>[PAWN_nameDef] earned a living making and selling chairs, with the occasional table thrown in too. [PAWN_possessive] work even managed to catch the eye of a rather high ranking member of Great House Telvanni. One day [PAWN_nameDef] woke up, ready to fulfil the days orders, only to find every single chair, and table, missing.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -1078,7 +1078,7 @@
 		<defName>ESCP_Dunmer_CorprusariumBackstory</defName>
 		<title>corprusarium worker</title>
 		<titleShort>corprusarium</titleShort>
-		<baseDescription>[PAWN_nameDef] was always willing to help people, no matter the circumstances. This somehow lead [PAWN_nameDef] to Tel Fyr, or more accurately the halls under it. [PAWN_pronoun] quickly learnt how to tend to the corprus victims, and became quite adept at it.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was always willing to help people, no matter the circumstances. This somehow led [PAWN_nameDef] to Tel Fyr, or more accurately the halls under it. [PAWN_pronoun] quickly learnt how to tend to the corprus victims, and became quite adept at it.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>

--- a/1.3/Defs/Backstories/Backstories_GreatHouse_Dres.xml
+++ b/1.3/Defs/Backstories/Backstories_GreatHouse_Dres.xml
@@ -5,7 +5,7 @@
 		<defName>ESCP_Dunmer_DresBackstory</defName>
 		<title>house Dres member</title>
 		<titleShort>Dres member</titleShort>
-		<baseDescription>[PAWN_nameDef] was a member of the Great House Dres. An often forgotten Great House, but a highly important one. House Dres was known for slavery, and nothing else. Any Argonian in House Dres territory was a slave, and [PAWN_nameDef] liked it that way.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was a member of the Great House Dres, a traditionalist house famous for its slave plantations. Any Argonian in House Dres territory was a slave, and [PAWN_nameDef] liked it that way.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>

--- a/1.3/Defs/Backstories/Backstories_GreatHouse_Telvanni.xml
+++ b/1.3/Defs/Backstories/Backstories_GreatHouse_Telvanni.xml
@@ -5,7 +5,7 @@
 		<defName>ESCP_Dunmer_TelvanniBackstory</defName>
 		<title>house Telvanni member</title>
 		<titleShort>Telvanni member</titleShort>
-		<baseDescription>[PAWN_nameDef] was a member of the Great House Telvanni. Great House Telvanni is known for its wonderful and magical craftsmanship, creating houses out of the strangest materials. [PAWN_nameDef] learnt many wonderous things during [PAWN_possessive] time with House Telvanni, such as socialising is a waste of precious time and that caring about people is pointless.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was a member of the Great House Telvanni. Great House Telvanni is known for its wonderful and magical craftsmanship, creating houses out of the strangest materials. [PAWN_nameDef] learnt many wonderous things during [PAWN_possessive] time with House Telvanni, such as that socialising is a waste of precious time and that caring about other people is pointless.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>

--- a/1.3/Defs/Backstories/Backstories_Refugee.xml
+++ b/1.3/Defs/Backstories/Backstories_Refugee.xml
@@ -7,7 +7,7 @@
 		<defName>ESCP_Dunmer_RefugeeChildBackstoryA</defName>
 		<title>Red Year refugee</title>
 		<titleShort>child refugee</titleShort>
-		<baseDescription>[PAWN_nameDef] was simply a child during the Red Year. Though [PAWN_possessive] memories of the event are hazy, every night [PAWN_pronoun] wakes up in a cold sweat, as [PAWN_possessive] nightmares force her to relive the horror.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was simply a child during the Red Year. Though [PAWN_possessive] memories of the event are hazy, every night [PAWN_pronoun] wakes up in a cold sweat, as [PAWN_possessive] nightmares force [PAWN_objective] to relive the horror.</baseDescription>
 		<slot>Childhood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -115,7 +115,7 @@
 		<defName>ESCP_Dunmer_RefugeeBackstoryC</defName>
 		<title>Red Year refugee</title>
 		<titleShort>refugee</titleShort>
-		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] job at the local egg mine. Whilst [PAWN_nameDef] doesn't miss the claustrophobic tunnels, a small part of [PAWN_possessive] does miss the strange sounds the kwama made.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] job at the local egg mine. Whilst [PAWN_nameDef] doesn't miss the claustrophobic tunnels, a small part of [PAWN_objective] does miss the strange sounds the kwama made.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -225,7 +225,7 @@
 		<defName>ESCP_Dunmer_RefugeeBackstoryF</defName>
 		<title>Red Year refugee</title>
 		<titleShort>refugee</titleShort>
-		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] job as a skooma runner. In all the chaos [PAWN_nameDef] decided to finally try some skooma, hoping it would relax [PAWN_possessive].</baseDescription>
+		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] job as a skooma runner. In all the chaos [PAWN_nameDef] decided to finally try some skooma, hoping it would relax [PAWN_objective].</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -262,7 +262,7 @@
 		<defName>ESCP_Dunmer_RefugeeBackstoryG</defName>
 		<title>Red Year refugee</title>
 		<titleShort>refugee</titleShort>
-		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] highly popular corner club in Balmora. [PAWN_nameDef] often looks back fondly at [PAWN_pronoun] time spent running the corner club, and imagines what life may have been like if [PAWN_pronoun] was still in Balmora.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] highly popular corner club in Balmora. [PAWN_nameDef] often looks back fondly at [PAWN_possessive] time spent running the corner club, and imagines what life may have been like if [PAWN_pronoun] was still in Balmora.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>
@@ -297,7 +297,7 @@
 		<defName>ESCP_Dunmer_RefugeeBackstoryH</defName>
 		<title>Red Year refugee</title>
 		<titleShort>refugee</titleShort>
-		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] job as a gondolier in Vivec city. [PAWN_nameDef] often yearns for the simple days, peacefully rowing [PAWN_possessive] gondala between the cantons.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was forced out of Vvardenfell during the Red Year, leaving behind [PAWN_possessive] job as a gondolier in Vivec city. [PAWN_nameDef] often yearns for the simple days, peacefully rowing [PAWN_possessive] gondola between the cantons.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>

--- a/1.3/Defs/Backstories/Backstories_SpecialAdult.xml
+++ b/1.3/Defs/Backstories/Backstories_SpecialAdult.xml
@@ -34,7 +34,7 @@
 		<defName>ESCP_Dunmer_FathisBackstory</defName>
 		<title>false Nerevarine</title>
 		<titleShort>false Nerevarine</titleShort>
-		<baseDescription>[PAWN_nameDef] was lead to believe that [PAWN_pronoun] was Nerevarine reborn by a local Blades agent. This turned out to not be the case, but [PAWN_possessive] still believed. The locals of Sadrith Mora came to call [PAWN_nameDef] 'The Deranged', as [PAWN_pronoun] would constantly spout off about how [PAWN_possessive] was going to save Morrowind.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was lead to believe that [PAWN_pronoun] was Nerevarine reborn by a local Blades agent. This turned out to not be the case, but [PAWN_pronoun] still believed. The locals of Sadrith Mora came to call [PAWN_nameDef] 'The Deranged', as [PAWN_pronoun] would constantly spout off about how [PAWN_pronoun] was going to save Morrowind.</baseDescription>
 		<slot>Adulthood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>

--- a/1.3/Defs/Backstories/abbotor/Backstories_GenericChild.xml
+++ b/1.3/Defs/Backstories/abbotor/Backstories_GenericChild.xml
@@ -88,7 +88,7 @@
 		<defName>ESCP_abbator_Dunmer_HouseNoble</defName>
 		<title>Dunmer house noble</title>
 		<titleShort>noble</titleShort>
-		<baseDescription>[PAWN_nameDef] was born into a noble family, a wealthy dunmer House of some repute. [PAWN_pronoun] has known the taste of the silver spoon and is used to getting [PAWN_possessive] way, but [PAWN_possessive] status also brought the privilege of a quality education and the ability to lead with a commanding presence.</baseDescription>
+		<baseDescription>[PAWN_nameDef] was born into a noble Dunmer family of some repute. [PAWN_pronoun] has known the taste of the silver spoon and is used to getting [PAWN_possessive] way, but [PAWN_possessive] status also brought the privilege of a quality education and the ability to lead with a commanding presence.</baseDescription>
 		<slot>Childhood</slot>
 		<spawnCategories>
 		  <li>ESCP_DunmerBackstory</li>


### PR DESCRIPTION
Most of these are just minor spelling and grammar edits.

The only more substantive ones were:

-the Great House Dres member: the description says "an often forgotten Great House" - this is probably true in the real world (since they weren't featured in TES3), but i'm not sure it makes sense in-universe, where their slave trade is central to Morrowind's economy, and along with their raids into Black Marsh is an extremely important & controversial set of political issues. So I rephrased it slightly to omit the bit about being often forgotten.

-the Dunmer House Noble backstory: as written it seemed to treat "Great House" and "noble family" as synonymous, when they're normally interpreted as being distinct concepts in Morrowind (i.e. a Great House might contain multiple different noble families)

-the Buoyant Armriger backstory: it described the Armrigers as a "mercenary faction of sorts", which I don't think is accurate - they're a militant holy order, not mercenaries?


Also this is the first time i've used github in ages, and it takes a bit of readjusting, so apologies if there's something horribly wrong with this pull request.